### PR TITLE
add gyro packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 zig-cache/
 build_runner.zig
+deps.zig
+gyro.lock

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,0 +1,20 @@
+pkgs:
+  zalgebra:
+    version: 0.0.0
+    description: "Linear algebra library for games and real-time computer graphics."
+    license: MIT
+    source_url: "https://github.com/kooparse/zalgebra"
+    tags:
+      math
+      linear-algebra
+      graphics
+      gamedev
+      matrix
+      quaternion
+
+    root: src/main.zig
+    files:
+      README.md
+      LICENSE
+      build.zig
+      src/*.zig


### PR DESCRIPTION
Hello! I'm working on a zig package manager called [gyro](https://github.com/mattnite/gyro), formerly known as zkg as I've added a proper packaging system involving a semi-centralized package index at [astrolabe.pm](https://astrolabe.pm).

With your blessing I'd love to add some packaging metadata so that this library can be added to the index (the package system uses semantic versioning where sub v1 versions aren't treated differently). The index has a concept of users, but I haven't added auth yet so I'm just manually curating and managing packages until I have that plugged in, so would you like me to publish this under the username kooparse?