### PR TITLE
Add a function to rotate a vector by a quaternion

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ to_mat4 | Convert given quat to rotation 4x4 matrix
 from_euler_angle | Construct quaternion from Euler angle
 from_axis | Construct quat from angle around specified axis
 extract_rotation | Get euler angles from given quaternion
+rotate_vec | Rotate given vector
 
 
 ### Utilities

--- a/src/quaternion.zig
+++ b/src/quaternion.zig
@@ -234,9 +234,9 @@ pub fn Quaternion(comptime T: type) type {
             return Vec3(T).new(root.to_degrees(yaw), root.to_degrees(pitch), root.to_degrees(roll));
         }
 
-        /// Rotate the vector v using the sandwich product
-        /// Taken from Foundations of Game Engine Development Vol. 1 Mathematics
-        pub fn rotate(self: Self, v: Vec3(T)) Vec3(T) {
+        /// Rotate the vector v using the sandwich product.
+        /// Taken from "Foundations of Game Engine Development Vol. 1 Mathematics".
+        pub fn rotate_vec(self: Self, v: Vec3(T)) Vec3(T) {
             const q = self.norm();
             const b = Vec3(T).new(q.x, q.y, q.z);
             const b2 = b.x * b.x + b.y * b.y + b.z * b.z;
@@ -310,13 +310,13 @@ test "zalgebra.Quaternion.extract_rotation" {
     testing.expectEqual(vec3.is_eq(res_q1, vec3.new(129.6000213623047, 44.427005767822266, 114.41073608398438)), true);
 }
 
-test "zalgebra.Quaternion.rotate" {
+test "zalgebra.Quaternion.rotate_vec" {
     const eps_value = comptime std.math.epsilon(f32);
     const q = quat.from_euler_angle(vec3.new(45, 45, 45));
     const m = q.to_mat4();
 
     const v = vec3.new(0, 1, 0);
-    const v1 = q.rotate(v);
+    const v1 = q.rotate_vec(v);
     const v2 = m.mult_by_vec4(vec4.new(v.x, v.y, v.z, 1.0));
 
     testing.expect(std.math.approxEqAbs(f32, v1.x, -1.46446585e-01, eps_value));


### PR DESCRIPTION
Hello again, I'm using the library in a project of mine and I realised it was missing a function to rotate a vector by a quaternion.
I've added a test for it and I'm also testing the function in a small project of mine and it seems to be working fine :)

