### PR TITLE
Replace `Mat.debugPrint` with `std.fmt.format` API

### DIFF
--- a/src/mat3.zig
+++ b/src/mat3.zig
@@ -275,27 +275,29 @@ pub fn Mat3x3(comptime T: type) type {
             return inv_mat;
         }
 
+        pub fn format(
+            self: Self,
+            comptime fmt: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = fmt;
+            _ = options;
+
+            for(0..3) |y| {
+                writer.writeAll("(");
+                for (0..3) |x| {
+                    writer.print("{d}, ", .{self.data[x][y]});
+                }
+                writer.writeAll(")\n");
+            }
+        }
+
+        /// Deprecated; use `std.fmt.bufPrint` or similar.
+        ///
         /// Print the 3x3 to stderr.
         pub fn debugPrint(self: Self) void {
-            const print = std.debug.print;
-
-            print("({d}, {d}, {d})\n", .{
-                self.data[0][0],
-                self.data[1][0],
-                self.data[2][0],
-            });
-
-            print("({d}, {d}, {d})\n", .{
-                self.data[0][1],
-                self.data[1][1],
-                self.data[2][1],
-            });
-
-            print("({d}, {d}, {d})\n", .{
-                self.data[0][2],
-                self.data[1][2],
-                self.data[2][2],
-            });
+            std.debug.print("{}", .{self});
         }
 
         /// Cast a type to another type.

--- a/src/mat3.zig
+++ b/src/mat3.zig
@@ -284,7 +284,7 @@ pub fn Mat3x3(comptime T: type) type {
             _ = fmt;
             _ = options;
 
-            for(0..3) |i| {
+            for (0..3) |i| {
                 writer.print("({d}, {d}, {d})\n", .{
                     self.data[0][i],
                     self.data[1][i],

--- a/src/mat3.zig
+++ b/src/mat3.zig
@@ -285,7 +285,7 @@ pub fn Mat3x3(comptime T: type) type {
             _ = options;
 
             for (0..3) |i| {
-                writer.print("({d}, {d}, {d})\n", .{
+                writer.print("({d:.2}, {d:.2}, {d:.2})\n", .{
                     self.data[0][i],
                     self.data[1][i],
                     self.data[2][i],

--- a/src/mat3.zig
+++ b/src/mat3.zig
@@ -284,12 +284,12 @@ pub fn Mat3x3(comptime T: type) type {
             _ = fmt;
             _ = options;
 
-            for(0..3) |y| {
-                writer.writeAll("(");
-                for (0..3) |x| {
-                    writer.print("{d}, ", .{self.data[x][y]});
-                }
-                writer.writeAll(")\n");
+            for(0..3) |i| {
+                writer.print("({d}, {d}, {d})\n", .{
+                    self.data[0][i],
+                    self.data[1][i],
+                    self.data[2][i],
+                });
             }
         }
 

--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -440,37 +440,29 @@ pub fn Mat4x4(comptime T: type) type {
             };
         }
 
+        pub fn format(
+            self: Self,
+            comptime fmt: []const u8,
+            options: std.fmt.FormatOptions,
+            writer: anytype,
+        ) !void {
+            _ = fmt;
+            _ = options;
+
+            for(0..4) |y| {
+                writer.writeAll("(");
+                for (0..4) |x| {
+                    writer.print("{d}, ", .{self.data[x][y]});
+                }
+                writer.writeAll(")\n");
+            }
+        }
+
+        /// Deprecated; use `std.fmt.bufPrint` or similar.
+        ///
         /// Print the 4x4 to stderr.
         pub fn debugPrint(self: Self) void {
-            const print = std.debug.print;
-
-            print("({d}, {d}, {d}, {d})\n", .{
-                self.data[0][0],
-                self.data[1][0],
-                self.data[2][0],
-                self.data[3][0],
-            });
-
-            print("({d}, {d}, {d}, {d})\n", .{
-                self.data[0][1],
-                self.data[1][1],
-                self.data[2][1],
-                self.data[3][1],
-            });
-
-            print("({d}, {d}, {d}, {d})\n", .{
-                self.data[0][2],
-                self.data[1][2],
-                self.data[2][2],
-                self.data[3][2],
-            });
-
-            print("({d}, {d}, {d}, {d})\n", .{
-                self.data[0][3],
-                self.data[1][3],
-                self.data[2][3],
-                self.data[3][3],
-            });
+            std.debug.print("{}", .{self});
         }
 
         /// Cast a type to another type.

--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -450,7 +450,7 @@ pub fn Mat4x4(comptime T: type) type {
             _ = options;
 
             for (0..4) |i| {
-                writer.print("({d}, {d}, {d}, {d})\n", .{
+                writer.print("({d:.2}, {d:.2}, {d:.2}, {d:.2})\n", .{
                     self.data[0][i],
                     self.data[1][i],
                     self.data[2][i],

--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -449,7 +449,7 @@ pub fn Mat4x4(comptime T: type) type {
             _ = fmt;
             _ = options;
 
-            for(0..4) |i| {
+            for (0..4) |i| {
                 writer.print("({d}, {d}, {d}, {d})\n", .{
                     self.data[0][i],
                     self.data[1][i],

--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -449,12 +449,13 @@ pub fn Mat4x4(comptime T: type) type {
             _ = fmt;
             _ = options;
 
-            for(0..4) |y| {
-                writer.writeAll("(");
-                for (0..4) |x| {
-                    writer.print("{d}, ", .{self.data[x][y]});
-                }
-                writer.writeAll(")\n");
+            for(0..4) |i| {
+                writer.print("({d}, {d}, {d}, {d})\n", .{
+                    self.data[0][i],
+                    self.data[1][i],
+                    self.data[2][i],
+                    self.data[3][i],
+                });
             }
         }
 


### PR DESCRIPTION
This PR uses the `std.fmt.format` API to allow users to print their matrices with supporting functions, including `std.debug.print`, `std.log.*` or `std.fmt.allocPrint`. It can look like this:

```zig
const matrix = Mat4.identity();
std.debug.print("{}", .{matrix});
// Output:
// (1, 0, 0, 0)
// (0, 1, 0, 0)
// (0, 0, 1, 0)
// (0, 0, 0, 1)
```