### PR TITLE
Matrix construction performance improvements

### DIFF
--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -242,18 +242,17 @@ pub fn Mat4x4(comptime T: type) type {
         /// Note: Field of view is given in degrees.
         /// Also for more details https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml.
         pub fn perspective(fovy_in_degrees: T, aspect_ratio: T, z_near: T, z_far: T) Self {
-            var result = Self.identity();
-
             const f = 1 / @tan(root.toRadians(fovy_in_degrees) * 0.5);
+            const nf = 1 / (z_near - z_far);
 
-            result.data[0][0] = f / aspect_ratio;
-            result.data[1][1] = f;
-            result.data[2][2] = (z_near + z_far) / (z_near - z_far);
-            result.data[2][3] = -1;
-            result.data[3][2] = 2 * z_far * z_near / (z_near - z_far);
-            result.data[3][3] = 0;
-
-            return result;
+            return .{
+                .data = .{
+                    .{ f / aspect_ratio, 0, 0, 0 },
+                    .{ 0, f, 0, 0 },
+                    .{ 0, 0, (z_near + z_far) * nf, -1 },
+                    .{ 0, 0, 2 * z_near * z_far * nf, 0 },
+                },
+            };
         }
 
         /// Construct a perspective 4x4 matrix with reverse Z and infinite far plane.


### PR DESCRIPTION
I only changed Mat4.perspective because that's what first caught my attention, and I didn't want to invest time in changing all of the other constructors if you don't like the idea.

If you do like this change, then I can go ahead and change the other constructors too.

This change makes the Mat4.perspective constructor typically about 1.25x faster on my PC. I benchmarked by creating 10 million Mat4s with the two different versions of the constructor. Generally the numbers were roughly like this: 190ms old, 150ms new.