### PR TITLE
optimized cross product

### DIFF
--- a/src/generic_vector.zig
+++ b/src/generic_vector.zig
@@ -102,18 +102,17 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
 
                 /// Construct the cross product (as vector) from two vectors.
                 pub fn cross(first_vector: Self, second_vector: Self) Self {
-                    const x1 = first_vector.x();
-                    const y1 = first_vector.y();
-                    const z1 = first_vector.z();
+                    // https://geometrian.com/resources/cross_product/
+                    const mask0 = [3]i32{ 1, 2, 0 };
+                    const mask1 = [3]i32{ 2, 0, 1 };
 
-                    const x2 = second_vector.x();
-                    const y2 = second_vector.y();
-                    const z2 = second_vector.z();
-
-                    const result_x = (y1 * z2) - (z1 * y2);
-                    const result_y = (z1 * x2) - (x1 * z2);
-                    const result_z = (x1 * y2) - (y1 * x2);
-                    return new(result_x, result_y, result_z);
+                    const tmp0 = @shuffle(T, first_vector.data, undefined, mask0);
+                    const tmp1 = @shuffle(T, second_vector.data, undefined, mask1);
+                    const tmp2 = tmp0 * second_vector.data;
+                    const tmp3 = tmp0 * tmp1;
+                    const tmp4 = @shuffle(T, tmp2, undefined, mask0);
+                    const result = tmp3 - tmp4;
+                    return .{ .data = result };
                 }
 
                 pub inline fn toVec2(self: Self) GenericVector(2, T) {


### PR DESCRIPTION
Hey, I've implemented an optimized version of `cross()` taken from https://geometrian.com/resources/cross_product/.
It shaves off a couple of instructions compared to the current implementation ([godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1AAvPMFJL6yAngGVG6AMKpaAVxYM9DgDJ4GmADl3ACNMYhAAJgBOUgAHVAVCWwZnNw89eMSbAV9/IJZQ8OiLTCtshiECJmICVPdPLhKy5MrqglzAkLDImIUqmrr0xr62jvzCnoBKC1RXYmR2DjQGPoBqADVMZABmVYBSbYARVYABTesSCG3SVaptiMmDgCE9jQBBV7fMVXia24ZVshiAkFNQ8MQ%2BgB9ABuWyI4Q2W2uqyUy3QMLhJBAiJ2kxxuz2AHYXu9VmTAQI1qouPsjrdwVDYRdiHsAKxPDRsw7PT7kikrAirACeNIOxxoEIIGOZbKeXC5PNJ5OWa2MorpEsZmJZ7IiCu2JI%2BSrJKsFqgitOOqIE6KZ8NlnNZ3INvOVlMFQotYpRWxt0vt7PlTsVbz5ptWxi9dOtDFt2tleuDLverpN7tWxEwClctClqktqwgItWACoIw9VgBaQtq0vCh4hsPpzPZ3OQoUFiC1svmvHViDUuuRx7J0NugUZrM5qXGTuDsuevuF4s9hujvmZghzAEAOiJT0nrbzNxb0/bJ6nbdnROdhpvn0%2B31%2BgqoAKBIIAshg8DRMOgwZK/pYviNwxnGzLYuc2x4lB%2BzEqm/JrCwTAKAA1hoBaytsXJ4Pc%2B6rI0qwRDcGH3uu45IShqHqscWE4XhxJESRNyioSt4PsaiGCgQLCxKRdInAoCCuFQVD0NQ9w3JqUp2iQNyuLGmA0P46A3MhaEaCOhpNhOPGxDRpxCSJYmYBJxE%2BmiQFkKsClYMpf5qVRXBaQh4Z6VGxwQHpGFlmBVkuZxbm8QSdJebxPmrHpzmNhR3G8ZIBaCcJoniXc5nufJin2apqzqehAVjmSm7boWem7NWemSAV97vBw0y0JwrK8J4HBaKQqCcAAWmYKKzPMmD7BE2w8KQBCaHV0yoSA2zbDuM3zQti0AGz6JwkjNeN7WcLwCggBoo3jdMcCwEgaC8XQYTkJQZ2xBd4TGBoUj7TQuZhLtEDBJtwR%2BNUQqcCN33MMQQoAPLBNocL/bwZ1sIIIMMLQf2tbwWDBK4wCOGItC7dwKOYMhRjiMjpD4Jm1h4LCONtd8WyuAQiwjX49MNcTtB4MExC/c4WCbQQxB4CwUOkLCxDBAkmCHPjhjAGzRiHXwBjAAo6x4JgADuIOxIwQv8IIIhiOwUgyIIigqOoxO6I0Bhy6Y5hs8Eu2QNMqCxOUOOViDqwAEqlJgKGYAAYihBC8KgIv81gjsQNMlhwsk9ixoMDSkD4fidAU3SNJkSQCEnGQJDnDBjF04TDL75MCK0AwuPUeixxXFT9O0afjJnFhN3nwxN8XGelzHfULBI9WNRtxMdRwEY9RoO5SDuGEQLghAkINw2TLwY3I5Mk3TbNi17/NK0s%2BtpCC1wGj7S1bXjzte0HZvpDHYgKCoOd9BkBQEA3XdIAPU9fB0PTCElBPrE0Br9IWYDgZgwhtYIWMNGAEHhojTaqN0aY1oNjIWWACYy0WG1UmcdKabRpsgOmDNeBM1KJte2nNgbczwevfmgtcbCzCGLJQkscGy1APfMSTAlYq3VprbWLDdbCFEOII2YjTZqE2roYi1sTBmH0OzKOztXbJHdp7H29B/ZBzWJWfowBMCCiYNUZACAlqSErLLVwqhQ7hzwJHeAMdy7lATk4GuQwU6xh7hMLOBdyidziIE5Ifi2713KFXWoXjk6RJaN3FuJc64d1iSk0YSTe5DxmHMQezlVocCaqQS%2BodOCT2AKsaes956L3hCvZy69DrbxmnNfee8CnH1PufYpm1r4WFvhvLQW8CkRFHlfbad8hnTBFokOwkggA%3D%3D)).

Quick benchmark calculating 1000000 cross products of random vectors using zBench (on a M1 Mac):
```
benchmark              runs     total time     time/run (avg ± σ)     (min ... max)                p75        p99        p995
-----------------------------------------------------------------------------------------------------------------------------
cross old              561      4.871s         8.684ms ± 182.953us    (8.442ms ... 9.503ms)        8.699ms    9.408ms    9.445ms
cross new              590      5.009s         8.49ms ± 199.771us     (8.257ms ... 9.855ms)        8.512ms    9.263ms    9.368ms
```
I suspect that the difference would be bigger with more advanced SIMD instructions than the 128-bit ones on a M1.