### PR TITLE
Remove `usingnamespace`

### DIFF
--- a/src/generic_vector.zig
+++ b/src/generic_vector.zig
@@ -183,7 +183,7 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
             else => unreachable,
         };
 
-        pub usingnamespace DimensionImpl;
+        pub const new = DimensionImpl.new;
 
         pub inline fn x(self: Self) T {
             return self.data[0];
@@ -193,6 +193,9 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
             return self.data[1];
         }
 
+        pub const z = DimensionImpl.z;
+        pub const w = DimensionImpl.w;
+
         pub inline fn xMut(self: *Self) *T {
             return &self.data[0];
         }
@@ -200,6 +203,9 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
         pub inline fn yMut(self: *Self) *T {
             return &self.data[1];
         }
+
+        pub const zMut = DimensionImpl.zMut;
+        pub const wMut = DimensionImpl.wMut;
 
         /// Set all components to the same given value.
         pub fn set(val: T) Self {
@@ -247,6 +253,9 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
             return right().negate();
         }
 
+        pub const forward = DimensionImpl.forward;
+        pub const back = DimensionImpl.back;
+
         /// Negate the given vector.
         pub fn negate(self: Self) Self {
             return self.scale(-1);
@@ -274,6 +283,14 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
             const result = slice[0..dimensions].*;
             return .{ .data = result };
         }
+
+        pub const fromVec2 = DimensionImpl.fromVec2;
+        pub const fromVec3 = DimensionImpl.fromVec3;
+        pub const fromVec4 = DimensionImpl.fromVec4;
+
+        pub const toVec2 = DimensionImpl.toVec2;
+        pub const toVec3 = DimensionImpl.toVec3;
+        pub const toVec4 = DimensionImpl.toVec4;
 
         /// Transform vector to array.
         pub fn toArray(self: Self) [dimensions]T {
@@ -375,6 +392,9 @@ pub fn GenericVector(comptime dimensions: comptime_int, comptime T: type) type {
             const result = from + (to - from) * @as(Data, @splat(t));
             return .{ .data = result };
         }
+
+        pub const rotate = DimensionImpl.rotate;
+        pub const cross = DimensionImpl.cross;
 
         pub fn swizzle(self: Self, comptime comps: []const u8) SwizzleType(comps.len) {
             if (comps.len == 1) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,19 +6,47 @@ const math = std.math;
 
 const generic_vector = @import("generic_vector.zig");
 
-pub usingnamespace generic_vector;
+pub const Vec2 = generic_vector.Vec2;
+pub const Vec2_f64 = generic_vector.Vec2_f64;
+pub const Vec2_i32 = generic_vector.Vec2_i32;
+pub const Vec2_usize = generic_vector.Vec2_usize;
+
+pub const Vec3 = generic_vector.Vec3;
+pub const Vec3_f64 = generic_vector.Vec3_f64;
+pub const Vec3_i32 = generic_vector.Vec3_i32;
+pub const Vec3_usize = generic_vector.Vec3_usize;
+
+pub const Vec4 = generic_vector.Vec4;
+pub const Vec4_f64 = generic_vector.Vec4_f64;
+pub const Vec4_i32 = generic_vector.Vec4_i32;
+pub const Vec4_usize = generic_vector.Vec4_usize;
+
+pub const GenericVector = generic_vector.GenericVector;
 
 const mat3 = @import("mat3.zig");
 
-pub usingnamespace mat3;
+pub const Mat3 = mat3.Mat3;
+pub const Mat3_f64 = mat3.Mat3_f64;
+
+pub const Mat3x3 = mat3.Mat3x3;
 
 const mat4 = @import("mat4.zig");
 
-pub usingnamespace mat4;
+pub const Mat4 = mat4.Mat4;
+pub const Mat4_f64 = mat4.Mat4_f64;
+pub const perspective = mat4.perspective;
+pub const perspectiveReversedZ = mat4.perspectiveReversedZ;
+pub const orthographic = mat4.orthographic;
+pub const lookAt = mat4.lookAt;
+
+pub const Mat4x4 = mat4.Mat4x4;
 
 const quat = @import("quaternion.zig");
 
-pub usingnamespace quat;
+pub const Quat = quat.Quat;
+pub const Quat_f64 = quat.Quaternion;
+
+pub const Quaternion = quat.Quaternion;
 
 /// Convert degrees to radians.
 pub fn toRadians(degrees: anytype) @TypeOf(degrees) {


### PR DESCRIPTION
`usingnamespace` has been removed in https://www.github.com/ziglang/zig/pull/24362. 

This PR follows @rohlem’s suggested approach, described here (big thanks to him): https://www.github.com/ziglang/zig/issues/20663#issuecomment-2234260723