### PR TITLE
remove usingnamespace; update build.zig; rename generic_vector.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,16 +16,16 @@ pub fn build(b: *Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zalgebra", .{
+    const mod = b.addModule("zalgebra", .{
         .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
     });
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
     const main_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = mod,
     });
 
     const run_main_tests = b.addRunArtifact(main_tests);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,10 +4,37 @@ const std = @import("std");
 const expectEqual = std.testing.expectEqual;
 const math = std.math;
 
-pub usingnamespace @import("generic_vector.zig");
-pub usingnamespace @import("mat3.zig");
-pub usingnamespace @import("mat4.zig");
-pub usingnamespace @import("quaternion.zig");
+pub const vector = @import("vector.zig");
+pub const mat3 = @import("mat3.zig");
+pub const mat4 = @import("mat4.zig");
+pub const quaternion = @import("quaternion.zig");
+
+// For backwards compat, emulate the usingnamespace to gather all the pub types under one umbrella.
+/// Deprecated: Use `vector.Vec2` instead.
+pub const Vec2 = vector.Vec2;
+/// Deprecated: Use `vector.Vec2_f64` instead.
+pub const Vec2_f64 = vector.Vec2_f64;
+/// Deprecated: Use `vector.Vec2_i32` instead.
+pub const Vec2_i32 = vector.Vec2_i32;
+/// Deprecated: Use `vector.Vec2_usize` instead.
+pub const Vec2_usize = vector.Vec2_usize;
+/// Deprecated: Use `vector.Vec3` instead.
+pub const Vec3 = vector.Vec3;
+/// Deprecated: Use `vector.Vec3_f64` instead.
+pub const Vec3_f64 = vector.Vec3_f64;
+/// Deprecated: Use `vector.Vec3_i32` instead.
+pub const Vec3_i32 = vector.Vec3_i32;
+/// Deprecated: Use `vector.Vec3_usize` instead.
+pub const Vec3_usize = vector.Vec3_usize;
+/// Deprecated: Use `vector.Vec4` instead.
+pub const Vec4 = vector.Vec4;
+/// Deprecated: Use `vector.Vec4_f64` instead.
+pub const Vec4_f64 = vector.Vec4_f64;
+/// Deprecated: Use `vector.Vec4_i32` instead.
+pub const Vec4_i32 = vector.Vec4_i32;
+/// Deprecated: Use `vector.Vec4_usize` instead.
+pub const Vec4_usize = vector.Vec4_usize;
+pub const GenericVector = vector.GenericVector;
 
 /// Convert degrees to radians.
 pub fn toRadians(degrees: anytype) @TypeOf(degrees) {

--- a/src/mat3.zig
+++ b/src/mat3.zig
@@ -4,12 +4,12 @@ const meta = std.meta;
 const mem = std.mem;
 const expectEqual = std.testing.expectEqual;
 const root = @import("main.zig");
-const generic_vector = @import("generic_vector.zig");
+const vector = @import("vector.zig");
 const quat = @import("quaternion.zig");
 
-const Vec3 = generic_vector.Vec3;
-const Vec3_f64 = generic_vector.Vec3_f64;
-const GenericVector = generic_vector.GenericVector;
+const Vec3 = vector.Vec3;
+const Vec3_f64 = vector.Vec3_f64;
+const GenericVector = vector.GenericVector;
 const Quaternion = quat.Quaternion;
 const Quat = quat.Quat;
 

--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -4,12 +4,12 @@ const meta = std.meta;
 const mem = std.mem;
 const expectEqual = std.testing.expectEqual;
 const root = @import("main.zig");
-const generic_vector = @import("generic_vector.zig");
+const vector = @import("vector.zig");
 const quat = @import("quaternion.zig");
 
-const Vec3 = generic_vector.Vec3;
-const Vec3_f64 = generic_vector.Vec3_f64;
-const GenericVector = generic_vector.GenericVector;
+const Vec3 = vector.Vec3;
+const Vec3_f64 = vector.Vec3_f64;
+const GenericVector = vector.GenericVector;
 const Quaternion = quat.Quaternion;
 const Quat = quat.Quat;
 

--- a/src/quaternion.zig
+++ b/src/quaternion.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const root = @import("main.zig");
 const meta = std.meta;
-const generic_vector = @import("generic_vector.zig");
+const vector = @import("vector.zig");
 const mat3 = @import("mat3.zig");
 const mat4 = @import("mat4.zig");
 const math = std.math;
@@ -12,10 +12,10 @@ const expectEqual = std.testing.expectEqual;
 const expect = std.testing.expect;
 const assert = std.debug.assert;
 
-const GenericVector = generic_vector.GenericVector;
+const GenericVector = vector.GenericVector;
 
-const Vec3 = generic_vector.Vec3;
-const Vec4 = generic_vector.Vec4;
+const Vec3 = vector.Vec3;
+const Vec4 = vector.Vec4;
 const Mat3x3 = mat3.Mat3x3;
 const Mat4x4 = mat4.Mat4x4;
 


### PR DESCRIPTION
`build.zig` - update to address breaking changes in zig build system
`root.zig` - removed `usingnamespace` which has been [recently removed](https://github.com/ziglang/zig/issues/20663)
Comments on the PR encourage embracing the namespaces rather than "spreading" it all into the top level of the library.
`generic_vector.zig` - renamed and removed usage of `usingnamespace`