### PR TITLE
Cover all tests

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -109,3 +109,10 @@ test "zalgebra.lerp" {
     try expectEqual(lerp(f32, from, to, 0.5), 5);
     try expectEqual(lerp(f32, from, to, 1), 10);
 }
+
+test {
+    _ = generic_vector;
+    _ = mat3;
+    _ = mat4;
+    _ = quat;
+}


### PR DESCRIPTION
When running 'zig build test' it only run test in main and now it runs all tests

Previously:
~/zalgebra: zig build test --summary all
Build Summary: 3/3 steps succeeded; 3/3 tests passed
test success
└─ run test 3 passed 355us MaxRSS:1M
   └─ zig test Debug native success 1s MaxRSS:239M

Now:
~/zalgebra: zig build test --summary all
Build Summary: 3/3 steps succeeded; 70/70 tests passed
test success
└─ run test 70 passed 1ms MaxRSS:3M
   └─ zig test Debug native success 1s MaxRSS:258M
