### PR TITLE
Change array multiplication operator ("**") to `@splat`

### DIFF
--- a/src/mat3.zig
+++ b/src/mat3.zig
@@ -44,7 +44,7 @@ pub fn Mat3x3(comptime T: type) type {
 
         /// Set all mat3 values to given value.
         pub fn set(value: T) Self {
-            const data: [9]T = .{value} ** 9;
+            const data: [9]T = @splat(value);
             return Self.fromSlice(&data);
         }
 

--- a/src/mat4.zig
+++ b/src/mat4.zig
@@ -54,7 +54,7 @@ pub fn Mat4x4(comptime T: type) type {
 
         /// Set all mat4 values to given value.
         pub fn set(value: T) Self {
-            const data: [16]T = .{value} ** 16;
+            const data: [16]T = @splat(value);
             return Self.fromSlice(&data);
         }
 


### PR DESCRIPTION
A month ago, the array multiplication operator was removed (https://codeberg.org/ziglang/zig/commit/72d954e7d3cfb8b46a26d5a199a9a5ecd36d87be)